### PR TITLE
Update simple:json-routes to 2.1.0

### DIFF
--- a/packages/meteor-oauth2-server/package.js
+++ b/packages/meteor-oauth2-server/package.js
@@ -11,7 +11,7 @@ Package.onUse(function(api) {
     api.use('webapp', 'server');
     api.use('check', 'server');
     api.use('meteorhacks:async@1.0.0', 'server');
-    api.use('simple:json-routes@2.0.0', 'server');
+    api.use('simple:json-routes@2.1.0', 'server');
 
     api.addFiles('common.js', ['client', 'server']);
     api.addFiles('meteor-model.js', 'server');


### PR DESCRIPTION
Using older versions of simple:json-routes leads to errors when used together with other packages such as iron:router, restivus and others (see e.g. https://github.com/kahmali/meteor-restivus/issues/185).

Updating simple:json-routes to 2.1.0 fixes the problems
